### PR TITLE
add one-click deep copy of iterable campaign

### DIFF
--- a/app/iterablegen/models.py
+++ b/app/iterablegen/models.py
@@ -87,8 +87,7 @@ class IterableCampaign(MetadataMixin):
     snippets = models.ManyToManyField('IterableSnippet', through='IterableCampaignSnippet')
 
     def get_snippets(self):
-        return self.snippets.order_by('snipets__order')
-
+        return self.snippets.order_by('snippets__order')
 
 class IterableCampaignCategory(MetadataMixin):
     class Meta:


### PR DESCRIPTION
add link to admin to allow for single click deep-copy of many-to-many modules on the campaign.